### PR TITLE
Add ability to query multiple logic variables

### DIFF
--- a/miniKanren/mk.rkt
+++ b/miniKanren/mk.rkt
@@ -62,11 +62,18 @@
          ((fresh (x) g0 g ...
             (lambdag@ (final-a)
               (choice ((reify x) final-a) empty-f)))
+          empty-a))))
+    ((_ n (x ...) g0 g ...)
+     (take n
+       (lambdaf@ ()
+         ((fresh (x ...) g0 g ...
+            (lambdag@ (final-a)
+              (list ((reify x) final-a) ...)))
           empty-a))))))
 
 (define-syntax run*
   (syntax-rules ()
-    ((_ (x) g ...) (run #f (x) g ...))))
+    ((_ (x ...) g ...) (run #f (x ...) g ...))))
 
 (define-syntax fresh
   (syntax-rules ()


### PR DESCRIPTION
refactor `run`
refactor `run*`

An extra pattern has been added in run to support multiple variables
this has been done to preserve backwards compatibility with existing
programs that only queried a single logic variable

Closes #3 